### PR TITLE
Add cascade delete to palettes

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('./knexfile')[environment];
 const database = require('knex')(configuration);
 
-app.locals.title = 'Test Server';
+app.locals.title = 'Palette Picker';
 app.use(cors());
 app.use(express.json());
 
@@ -29,8 +29,8 @@ app.get('/api/v1/palettes/:id', async (request, response) => {
 
   try {
     const palette = await database('palettes').where('id', id);
-    palette.length 
-      ? response.status(200).json(palette[0]) 
+    palette.length
+      ? response.status(200).json(palette[0])
       : response.status(404).json({
         error: `Could not find palette with the id: ${id}`
       });
@@ -63,7 +63,7 @@ app.delete('/api/v1/palettes', async (request, response) => {
     return response.status(422).json({ error: 'The expected format is: { id: <Number> }. You are missing the id property.'})
   };
   await database('palettes').where('id', parseInt(id)).del();
-  
+
   try {
     response.status(200).json(id)
   } catch (error) {

--- a/db/migrations/20200206144130_add-palette-name.js
+++ b/db/migrations/20200206144130_add-palette-name.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.table('palettes', table => {
+    table.string('name');
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('palettes', table => {
+    table.dropColumn('name');
+  })
+};

--- a/db/migrations/20200206145146_delete-projectid.js
+++ b/db/migrations/20200206145146_delete-projectid.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.table('palettes', table => {
+    table.dropColumn('project_id');
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('palettes', table => {
+    table.integer('project_id').unsigned()
+    table.foreign('project_id')
+    .references('projects.id');
+  })
+};

--- a/db/migrations/20200206145410_add-projectid-cascade.js
+++ b/db/migrations/20200206145410_add-projectid-cascade.js
@@ -1,0 +1,15 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('palettes', table => {
+    table.integer('project_id').unsigned()
+    table.foreign('project_id')
+    .references('projects.id')
+    .onDelete('CASCADE');
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('palettes', table => {
+    table.dropColumn('project_id');
+  });
+};


### PR DESCRIPTION
#### What's this PR do?
This PR adds the cascade delete to the palette so that if a project is deleted, the palettes associated with it will also be deleted.
#### Where should the reviewer start?
Check out the new migrations! 
#### How should this be manually tested?
Our tests are still passing on my end. Check that they are passing on yours!