### PR TITLE
Remove parseInt from palette delete

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,8 @@ app.delete('/api/v1/palettes', async (request, response) => {
   if (!id) {
     return response.status(422).json({ error: 'The expected format is: { id: <Number> }. You are missing the id property.'})
   };
-  await database('palettes').where('id', parseInt(id)).del();
+
+  await database('palettes').where('id', id).del();
 
   try {
     response.status(200).json(id);


### PR DESCRIPTION
It was unnecessary because the data type was already a number.